### PR TITLE
keyboard: Support `shift: false`

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,6 +120,9 @@ function createKeyboardEvent (type, options) {
     Object.defineProperty(e, 'which', {
       get: function () { return options.key; }
     });
+    Object.defineProperty(e, 'shiftKey', {
+      get: function () { return options.shift; }
+    });
   }
 
   return e;

--- a/test/tests.js
+++ b/test/tests.js
@@ -144,6 +144,10 @@ describe('keydown', function () {
     assert(13 === e.keyCode);
   });
 
+  it('should support `shift: false`', function(){
+    var e = create('keydown', { key: 'tab', shift: false });
+    assert(!e.shiftKey);
+  });
 });
 
 describe('keyup', function () {


### PR DESCRIPTION
More crazy hacks to get `shift: false` working when creating `keydown`s.

Without this patch, `e.shiftKey === true` every time.
